### PR TITLE
Bump chainsail-helpers version in pyproject.toml and Nix

### DIFF
--- a/chainsail_helpers/pyproject.toml
+++ b/chainsail_helpers/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chainsail-helpers"
-version = "0.1.2"
+version = "0.1.3"
 description = "Probability distribution interfaces, examples, and utilities for the Chainsail sampling service"
 authors = ["Simeon Carstens <simeon.carstens@tweag.io>"]
 license = "MIT"
@@ -16,14 +16,14 @@ concatenate-samples = 'chainsail_helpers.scripts.concatenate_samples:main'
 [tool.poetry.dependencies]
 python = "^3.8,<3.11"
 numpy = "^1.21.2"
-pymc3 = { version = "^3.11.4", optional = true }
+pymc = { version = "^4.1.4", optional = true }
 requests = { version = "^2.26.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 black = "^21.9b0"
 
 [tool.poetry.extras]
-pymc3 = [ "pymc3" ]
+pymc = [ "pymc" ]
 stan = [ "requests" ]
 
 [build-system]

--- a/examples/nix/chainsail_helpers.nix
+++ b/examples/nix/chainsail_helpers.nix
@@ -1,10 +1,10 @@
 { buildPythonPackage, fetchPypi, numpy }:
 buildPythonPackage rec {
   pname = "chainsail-helpers";
-  version = "0.1.1";
+  version = "0.1.3";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "261e83de5f9e4aca3be673c34aec09d7ccab35f40f1971c8b27f561fae6ce106";
+    sha256 = "0126il1smk2s9faa1bl5ly0xgqj8wfsfv7q9cbxfjl8yhp0h202z";
   };
   doCheck = false;
   propagatedBuildInputs = [ numpy ];

--- a/examples/pymc3-mixture/probability.py
+++ b/examples/pymc3-mixture/probability.py
@@ -5,7 +5,7 @@ Probability density of a Gaussian mixture defined by a PyMC model
 import numpy as np
 import pymc as pm
 
-from chainsail_helpers.pdf.pymc3 import PyMCPDF
+from chainsail_helpers.pdf.pymc import PyMCPDF
 
 
 means = np.array([[-1.0, -2.0], [1.0, 1.0], [3.0, 2.0], [2.0, -2.0]])


### PR DESCRIPTION
This bumps the `chainsail-helpers` version in the `pyproject.toml` and a Nix shell. Also fixes an occurrence of RESAAS.