### PR TITLE
Likelihood tempering for Stan PDF wrapper

### DIFF
--- a/chainsail_helpers/chainsail_helpers/pdf/stan/__init__.py
+++ b/chainsail_helpers/chainsail_helpers/pdf/stan/__init__.py
@@ -3,14 +3,140 @@ Interfaces for Chainsail probability densities defined by a Stan model
 """
 from __future__ import annotations
 
-from typing import Any
+import functools
+from typing import Any, Callable
+
 import numpy as np
 import requests
 
 from chainsail_helpers.pdf import PDF
 
 
-class StanPDF(PDF):
+class BaseStanPDF(PDF):
+    """
+    Chainsail PDF wrapper around httpstan
+    (https://github.com/stan-dev/httpstan).
+    """
+    _HTTPSTAN_URL = "http://localhost:8082"
+
+    def __init__(self, model_code: str, data: dict[str, Any] | None=None) -> None:
+        """
+        Initializes a Chainsail-compatible PDF wrapper around the httpstan
+        REST API.
+
+        Args:
+            model_code(string): Stan model specificaton that will be compiled
+              by httpstan
+            data(dict): observations to condition on
+        """
+        r = requests.post(
+            f"{self._HTTPSTAN_URL}/v1/models",
+            json={"program_code": model_code},
+        )
+        # if the model did not compile successfully, httpstan returns
+        # a 400 status code (bad request)
+        if r.status_code == 400:
+            raise Exception(
+                ("Model compilation failed. httpstan message:\n"
+                 f"{r.json()['message']}")
+            )
+        else:
+            r.raise_for_status()
+        model_id = r.json()["name"]
+        self._httpstan_model_route = f"{self._HTTPSTAN_URL}/v1/{model_id}"
+        self._data = data or {}
+
+    def _query_log_prob(self, x: np.ndarray,
+                        preflight_data_transform: Callable | None=None) -> float:
+        """
+        Uses the httpstan HTTP API to evaluate the model's log-probability.
+
+        Args:
+            x: 1D array of floats at which the log-likelihood is evaluated
+            preflight_data_transform: transformation to be applied to the data
+              before sending it to httpstan
+
+        Returns:
+            log-probability evaluated at `x`
+        """
+        try:
+            if preflight_data_transform:
+                data = preflight_data_transform(self._data)
+            else:
+                data = self._data
+            r = requests.post(
+                f"{self._httpstan_model_route}/log_prob",
+                json={
+                    "unconstrained_parameters": x.tolist(),
+                    "data": data,
+                    "adjust_transform": False,
+                },
+            )
+            r.raise_for_status()
+            return r.json()["log_prob"]
+        except Exception as e:
+            raise Exception(f"Querying log-prob failed: Error: {e}")
+
+    def _query_log_prob_gradient(self, x: np.ndarray, preflight_data_transform: Callable | None=None) -> np.ndarray:
+        """
+        Uses the httpstan HTTP API to evaluate the model's log-probability gradient.
+
+        Args:
+            x: 1D array of floats at which the log-probability's gradient is evaluated
+            preflight_data_transform: transformation to be applied to the data
+              before sending it to httpstan
+
+        Returns:
+            1D array with log-probability gradient evaluated at `x`
+        """
+        try:
+            if preflight_data_transform:
+                data = preflight_data_transform(self._data)
+            else:
+                data = self._data
+            r = requests.post(
+                f"{self._httpstan_model_route}/log_prob_grad",
+                json={
+                    "unconstrained_parameters": x.tolist(),
+                    "data": data,
+                    "adjust_transform": False,
+                },
+            )
+            r.raise_for_status()
+            return np.array(r.json()["log_prob_grad"])
+        except Exception as e:
+            raise Exception(f"Querying log-prob gradient failed: Error: {e}")
+
+    def log_prob(self, x: np.ndarray) -> float:
+        """
+        Log-probability of the density to be sampled.
+        Calls out to the httpstan server specified in self._httpstan_url.
+        Args:
+            x: 1D array of floats at which the log-probability
+              is evaluated
+
+        Returns:
+            log-probability evaluated at x
+        """
+        return self._query_log_prob(x)
+
+    def log_prob_gradient(self, x: np.ndarray) -> np.ndarray:
+        """
+        Gradient of the log-probability of the density to be sampled.
+        Calls out to the httpstan server specified in self._httpstan_url.
+
+        Args:
+            x: 1D array of floats at which the log-probability
+              gradient is evaluated
+
+        Returns:
+            1D array of floats containing the flattened
+              log-probability gradient evaluated at x
+        """
+        return self._query_log_prob_gradient(x)
+
+
+class PosteriorStanPDF(BaseStanPDF):
     """
     Chainsail PDF wrapper around httpstan
     (https://github.com/stan-dev/httpstan).
@@ -45,7 +171,7 @@ class StanPDF(PDF):
         self._data = data or {}
 
     @staticmethod
-    def _tag_data(data: dict[str, Any], include_prior: bool, include_likelihood: bool) -> dict[str, Any]:
+    def _tag_data(data: dict[str, Any], include_prior: bool=True, include_likelihood: bool=True) -> dict[str, Any]:
         """
         Adds tags / flags to the data that indicate whether the prior or likelihood should be included.
         Args:
@@ -57,63 +183,11 @@ class StanPDF(PDF):
 
         Returns:
             data dictionary with additional entries `include_prior` and `include_likelihood`, set to either
-              0 or 1.        
+              0 or 1.
         """
         return {**data,
                 "include_prior": int(include_prior),
                 "include_likelihood": int(include_likelihood)}
-
-    def _query_log_prob(self, x: np.ndarray, include_prior: bool=True, include_likelihood: bool=True) -> float:
-        """
-        Uses the httpstan HTTP API to evaluate the model's log-probability.
-
-        Args:
-            x: 1D array of floats at which the log-likelihood is evaluated
-            include_prior: whether the prior contributions are taken into account
-            include_likelihood: whether the likelihood is taken into account
-
-        Returns:
-            log-probability evaluated at `x`
-        """
-        try:
-            r = requests.post(
-                f"{self._httpstan_model_route}/log_prob",
-                json={
-                    "unconstrained_parameters": x.tolist(),
-                    "data": self._tag_data(self._data, include_prior, include_likelihood),
-                    "adjust_transform": False,
-                },
-            )
-            r.raise_for_status()
-            return r.json()["log_prob"]
-        except Exception as e:
-            raise Exception(f"Querying log-prob failed: Error: {e}")
-
-    def _query_log_prob_gradient(self, x: np.ndarray, include_prior: bool=True, include_likelihood: bool=True) -> np.ndarray:
-        """
-        Uses the httpstan HTTP API to evaluate the model's log-probability gradient.
-
-        Args:
-            x: 1D array of floats at which the log-probability's gradient is evaluated
-            include_prior: whether the prior contributions are taken into account
-            include_likelihood: whether the likelihood is taken into account
-
-        Returns:
-            1D array with log-probability gradient evaluated at `x`
-        """
-        try:
-            r = requests.post(
-                f"{self._httpstan_model_route}/log_prob_grad",
-                json={
-                    "unconstrained_parameters": x.tolist(),
-                    "data": self._tag_data(self._data, include_prior, include_likelihood),
-                    "adjust_transform": False,
-                },
-            )
-            r.raise_for_status()
-            return np.array(r.json()["log_prob_grad"])
-        except Exception as e:
-            raise Exception(f"Querying log-prob gradient failed: Error: {e}")
 
     def log_likelihood(self, x: np.ndarray) -> float:
         """
@@ -129,7 +203,8 @@ class StanPDF(PDF):
         Returns:
             log-likelihood evaluated at x
         """
-        return self._query_log_prob(x, include_prior=False)
+        preflight_data_transform = functools.partial(self._tag_data, include_prior=False)
+        return self._query_log_prob(x, preflight_data_transform)
 
     def log_prior(self, x: np.ndarray) -> float:
         """
@@ -145,7 +220,8 @@ class StanPDF(PDF):
         Returns:
             log-prior probability evaluated at x
         """
-        return self._query_log_prob(x, include_likelihood=False)
+        preflight_data_transform = functools.partial(self._tag_data, include_likelihood=False)
+        return self._query_log_prob(x, preflight_data_transform)
     
     def log_prob(self, x: np.ndarray) -> float:
         """
@@ -174,7 +250,8 @@ class StanPDF(PDF):
             1D array of floats containing the flattened
               gradient of the log-likelihood evaluated at x
         """
-        return self._query_log_prob_gradient(x, include_prior=False)
+        preflight_data_transform = functools.partial(self._tag_data, include_prior=False)
+        return self._query_log_prob_gradient(x, preflight_data_transform)
 
     def log_prior_gradient(self, x: np.ndarray) -> np.ndarray:
         """
@@ -190,7 +267,8 @@ class StanPDF(PDF):
             1D array of floats containing the flattened
               gradient of the log-prior density evaluated at x
         """
-        return self._query_log_prob_gradient(x, include_likelihood=False)
+        preflight_data_transform = functools.partial(self._tag_data, include_likelihood=False)
+        return self._query_log_prob_gradient(x, preflight_data_transform)
         
     def log_prob_gradient(self, x: np.ndarray) -> np.ndarray:
         """

--- a/chainsail_helpers/chainsail_helpers/pdf/stan/__init__.py
+++ b/chainsail_helpers/chainsail_helpers/pdf/stan/__init__.py
@@ -42,6 +42,74 @@ class StanPDF(PDF):
         self._httpstan_model_route = f"{self._HTTPSTAN_URL}/v1/{model_id}"
         self._data = data or {}
 
+    @staticmethod
+    def _tag_data(data, include_prior, include_likelihood):
+        return {**data,
+                "include_prior": int(include_prior),
+                "include_likelihood": int(include_likelihood)}
+
+    def _query_log_prob(self, x, include_prior=True, include_likelihood=True):
+        try:
+            r = requests.post(
+                f"{self._httpstan_model_route}/log_prob",
+                json={
+                    "unconstrained_parameters": x.tolist(),
+                    "data": self._tag_data(self._data, include_prior, include_likelihood),
+                    "adjust_transform": False,
+                },
+            )
+            r.raise_for_status()
+            return r.json()["log_prob"]
+        except Exception as e:
+            raise Exception(f"Querying log-prob failed: Error: {e}")
+
+    def _query_log_prob_gradient(self, x, include_prior=True, include_likelihood=True):
+        try:
+            r = requests.post(
+                f"{self._httpstan_model_route}/log_prob_grad",
+                json={
+                    "unconstrained_parameters": x.tolist(),
+                    "data": self._tag_data(self._data, include_prior, include_likelihood),
+                    "adjust_transform": False,
+                },
+            )
+            r.raise_for_status()
+            return np.array(r.json()["log_prob_grad"])
+        except Exception as e:
+            raise Exception(f"Querying log-prob gradient failed: Error: {e}")
+
+    def log_likelihood(self, x):
+        """
+        Evaluates the log-likelihood of the model.
+        
+        Calls out to the httpstan server specified in self._httpstan_url with
+        datums `include_prior` set to `0` and `include_likelihood` set to `1`.
+
+        Args:
+            x(np.ndarray): 1D array of floats at which the log-likelihood
+              is evaluated
+
+        Returns:
+            float: log-likelihood evaluated at x
+        """
+        return self._query_log_prob(x, include_prior=False)
+
+    def log_prior(self, x):
+        """
+        Evaluates the log-prior probability of the model.
+        
+        Calls out to the httpstan server specified in self._httpstan_url with
+        datums `include_prior` set to `1` and `include_likelihood` set to `0`.
+
+        Args:
+            x(np.ndarray): 1D array of floats at which the log-prior probability
+              is evaluated
+
+        Returns:
+            float: log-prior probability evaluated at x
+        """
+        return self._query_log_prob(x, include_likelihood=False)
+    
     def log_prob(self, x):
         """
         Log-probability of the density to be sampled.
@@ -53,20 +121,40 @@ class StanPDF(PDF):
         Returns:
             float: log-probability evaluated at x
         """
-        try:
-            r = requests.post(
-                f"{self._httpstan_model_route}/log_prob",
-                json={
-                    "unconstrained_parameters": x.tolist(),
-                    "data": self._data,
-                    "adjust_transform": False,
-                },
-            )
-            r.raise_for_status()
-            return r.json()["log_prob"]
-        except Exception as e:
-            raise Exception(f"Querying log-prob failed: Error: {e}")
+        return self._query_log_prob(x)
 
+    def log_likelihood_gradient(self, x):
+        """
+        Evaluates the gradient of the log-likelihood of the model.
+        Calls out to the httpstan server specified in self._httpstan_url
+        with datums `include_prior` set to `0` and `include_likelihood` set to `1`.
+
+        Args:
+            x(np.ndarray): 1D array of floats at which the gradient of the
+              log-likelihood is evaluated
+
+        Returns:
+            np.ndarray: 1D array of floats containing the flattened
+              gradient of the log-likelihood evaluated at x
+        """
+        return self._query_log_prob_gradient(x, include_prior=False)
+
+    def log_prior_gradient(self, x):
+        """
+        Evaluates the gradient of the log-prior density of the model.
+        Calls out to the httpstan server specified in self._httpstan_url
+        with datums `include_prior` set to `1` and `include_likelihood` set to `0`.
+
+        Args:
+            x(np.ndarray): 1D array of floats at which the gradient of the
+              log-prior density is evaluated
+
+        Returns:
+            np.ndarray: 1D array of floats containing the flattened
+              gradient of the log-prior density evaluated at x
+        """
+        return self._query_log_prob_gradient(x, include_likelihood=False)
+        
     def log_prob_gradient(self, x):
         """
         Gradient of the log-probability of the density to be sampled.
@@ -80,16 +168,4 @@ class StanPDF(PDF):
             np.ndarray: 1D array of floats containing the flattened
               log-probability gradient evaluated at x
         """
-        try:
-            r = requests.post(
-                f"{self._httpstan_model_route}/log_prob_grad",
-                json={
-                    "unconstrained_parameters": x.tolist(),
-                    "data": self._data,
-                    "adjust_transform": False,
-                },
-            )
-            r.raise_for_status()
-            return np.array(r.json()["log_prob_grad"])
-        except Exception as e:
-            raise Exception(f"Querying log-prob gradient failed: Error: {e}")
+        return self._query_log_prob_gradient(x)

--- a/chainsail_helpers/pyproject.toml
+++ b/chainsail_helpers/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chainsail-helpers"
-version = "0.1.4"
+version = "0.1.5"
 description = "Probability distribution interfaces, examples, and utilities for the Chainsail sampling service"
 authors = ["Simeon Carstens <simeon.carstens@tweag.io>"]
 license = "MIT"

--- a/documentation/algorithms/replica_exchange.md
+++ b/documentation/algorithms/replica_exchange.md
@@ -30,7 +30,8 @@ $$ p(x|D, \beta) \propto p(D|x)^\beta \times p(x) $$
 
 For $\beta=1$, we sample from the full posterior, while for $0 < \beta \ll 1$ the likelihood and thus the influence of the data are essentially switched off.
 
-Note that likelihood tempering is currently not supported for the [Stan and PyMC interfaces](https://github.com/tweag/chainsail-resources/tree/main/chainsail_helpers/chainsail_helpers/pdf).
+Note that likelihood tempering is currently not supported for the [PyMC interface](https://github.com/tweag/chainsail-resources/tree/main/chainsail_helpers/chainsail_helpers/pdf/pymc/__init__.py).
+When using likelihood tempering with the Stan interface, note that you have to make small modifications to your Stan model definition, as explained in the documentation for the [`PosteriorStanPDF`] class in the [Stan wrapper](https://github.com/tweag/chainsail-resources/tree/main/chainsail_helpers/chainsail_helpers/pdf/stan/__init__.py).
 
 ## Choice of inverse temperatures
 If, for two neighboring (in the schedule sense) replicas, the values for $\beta$ are too different, exchanges between those replicas are unlikely to be accepted.

--- a/examples/nix/chainsail_helpers.nix
+++ b/examples/nix/chainsail_helpers.nix
@@ -1,10 +1,10 @@
 { buildPythonPackage, fetchPypi, numpy }:
 buildPythonPackage rec {
   pname = "chainsail-helpers";
-  version = "0.1.4";
+  version = "0.1.5";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0nynphm3xk4saywyx7a6ljqklxc2pvdm5qzkqy5v4s867gwy93hk";
+    sha256 = "TODO after PyPi publication";
   };
   doCheck = false;
   propagatedBuildInputs = [ numpy ];

--- a/examples/stan-mixture/probability.py
+++ b/examples/stan-mixture/probability.py
@@ -4,7 +4,7 @@ Probability density of a Gaussian mixture defined by a Stan model
 
 import numpy as np
 
-from chainsail_helpers.pdf.stan import StanPDF
+from chainsail_helpers.pdf.stan import BaseStanPDF
 
 model_code = """
 parameters {
@@ -16,5 +16,5 @@ model {
 }
 """
 
-pdf = StanPDF(model_code)
+pdf = BaseStanPDF(model_code)
 initial_states = np.array([np.random.uniform(-2, 3)])


### PR DESCRIPTION
Adds support for likelihood tempering for the Stan PDF wrapper. This works by including additional "boolean" flags in the Stan model definition that allow switching on / off the likelihood / prior contributions. Credit for this idea goes to Stan developer @bob-carpenter (https://github.com/stan-dev/stan/issues/605#issuecomment-1348737675).