### PR TITLE
Remove cap on Python version

### DIFF
--- a/chainsail_helpers/pyproject.toml
+++ b/chainsail_helpers/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chainsail-helpers"
-version = "0.1.5"
+version = "0.1.5.1"
 description = "Probability distribution interfaces, examples, and utilities for the Chainsail sampling service"
 authors = ["Simeon Carstens <simeon.carstens@tweag.io>"]
 license = "MIT"
@@ -14,7 +14,7 @@ packages = [ { include = 'chainsail_helpers' } ]
 concatenate-samples = 'chainsail_helpers.scripts.concatenate_samples:main'
 
 [tool.poetry.dependencies]
-python = "^3.8,<3.11"
+python = ">=3.8"
 numpy = "^1.21.2"
 pymc = { version = "^4.1.4", optional = true }
 requests = { version = "^2.26.0", optional = true }

--- a/examples/nix/chainsail_helpers.nix
+++ b/examples/nix/chainsail_helpers.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   version = "0.1.5.1";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3f01e4e98fe4b13e675a92b7c2e44ce4df1b3fccad058e73ed140c5a5d85ca35";
+    sha256 = "2e69fa0ed98aa1e4024ac66fb2b212ad81bb0ca71792da029b49f45c73769dcd";
   };
   doCheck = false;
   propagatedBuildInputs = [ numpy ];

--- a/examples/nix/chainsail_helpers.nix
+++ b/examples/nix/chainsail_helpers.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage, fetchPypi, numpy }:
 buildPythonPackage rec {
   pname = "chainsail-helpers";
-  version = "0.1.5";
+  version = "0.1.5.1";
   src = fetchPypi {
     inherit pname version;
     sha256 = "3f01e4e98fe4b13e675a92b7c2e44ce4df1b3fccad058e73ed140c5a5d85ca35";


### PR DESCRIPTION
This cap leads to a whole lot of downstream issues, e.g. when using the new controller development workflow (3f01e4e98fe4b13e675a92b7c2e44ce4df1b3fccad058e73ed140c5a5d85ca35) and adding `chainsail-helpers` as a dependency to the rexfw runner's `pyproject.toml`.