### PR TITLE
Small changes to examples README and add example job specification

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This provides several simple use cases for Chainsail, in which a single Markov c
 
 The typical workflow to try out these use cases would be
 1. Run `python single_chain.py` in one of the example case directories (writes samples to a file `sc_samples.npy`, possibly install the dependencies in `requirements.txt`) and be unhappy with the result,
-2. run Chainsail using the same `probability.py`, but zipped and uploaded to some URL,
+2. run Chainsail using the same `probability.py`, but zipped and uploaded via the submission form,
 3. download the Chainsail results, unzip them and concatenate them to a single `numpy` array written to the example case directory by running (in this directory)
    ```bash
    $ unzip /path/to/results.zip -d /some/path
@@ -15,3 +15,5 @@ The typical workflow to try out these use cases would be
    ```
    `concatenate-samples` is a Python script available in the `chainsail-helpers` package.
 4. Run `python compare.py <example dir>/sc_samples.npy /some/path/chainsail_samples.npy` in the use case directory and (ideally) be amazed how much better Chainsail sampled your distribution :-)
+
+If you like to run one of these examples using the local controller-only deployment (https://github.com/tweag/chainsail/tree/main/app/controller#development-workflow), you'll also find an exemplary `job.json` job specification file in this directory.

--- a/examples/job.json
+++ b/examples/job.json
@@ -1,0 +1,25 @@
+{
+    "tempered_dist_family": "boltzmann",
+    "probability_definition": "wedon'tneedthat",
+    "max_replicas": 8,
+    "initial_number_of_replicas": 4,
+    "initial_schedule_parameters": {
+        "minimum_beta": 0.1
+    },
+    "optimization_parameters": {
+        "optimization_quantity_target": 0.8,
+	"decrement": 0.025,
+	"min_param": 0.1
+    },
+    "replica_exchange_parameters": {
+	"num_optimization_samples": 5000,
+	"num_production_samples": 10000,
+	"dump_interval": 500,
+	"status_interval": 500
+    },
+    "local_sampler": "naive_hmc",
+    "local_sampling_parameters": {
+	    "num_steps": 30,
+	    "num_adaption_samples": 500
+    }
+}


### PR DESCRIPTION
This adds an example job specification file (`job.json`). While doing that, I noticed that the examples README was outdated, so I fixed this and added a sentence about the job spec file to it.